### PR TITLE
My RoR Blog App - 12 api documentation

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -26,7 +26,7 @@ Metrics/ClassLength:
   Max: 150
 Metrics/BlockLength:
   AllowedMethods: ['describe']
-  Max: 30
+  Max: 60
 
 Style/Documentation:
   Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -74,11 +74,13 @@ group :test do
   gem 'webdrivers'
 end
 
+gem 'cancancan'
+
+gem 'devise', '~> 4.9'
+
+gem 'rswag'
+
 # Rubocop for linters checking
 gem 'rubocop', '>= 1.0', '< 2.0'
 
 gem 'will_paginate'
-
-gem 'devise', '~> 4.9'
-
-gem 'cancancan'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -133,6 +133,8 @@ GEM
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
     json (2.7.1)
+    json-schema (4.1.1)
+      addressable (>= 2.8)
     language_server-protocol (3.17.0.3)
     launchy (2.5.2)
       addressable (~> 2.8)
@@ -248,6 +250,21 @@ GEM
       rspec-mocks (~> 3.12)
       rspec-support (~> 3.12)
     rspec-support (3.12.1)
+    rswag (2.13.0)
+      rswag-api (= 2.13.0)
+      rswag-specs (= 2.13.0)
+      rswag-ui (= 2.13.0)
+    rswag-api (2.13.0)
+      activesupport (>= 3.1, < 7.2)
+      railties (>= 3.1, < 7.2)
+    rswag-specs (2.13.0)
+      activesupport (>= 3.1, < 7.2)
+      json-schema (>= 2.2, < 5.0)
+      railties (>= 3.1, < 7.2)
+      rspec-core (>= 2.14)
+    rswag-ui (2.13.0)
+      actionpack (>= 3.1, < 7.2)
+      railties (>= 3.1, < 7.2)
     rubocop (1.59.0)
       json (~> 2.3)
       language_server-protocol (>= 3.17.0)
@@ -319,8 +336,8 @@ DEPENDENCIES
   cancancan
   capybara
   debug
-  factory_bot_rails
   devise (~> 4.9)
+  factory_bot_rails
   importmap-rails
   jbuilder
   letter_opener
@@ -329,6 +346,7 @@ DEPENDENCIES
   rails (~> 7.1.2)
   rails-controller-testing
   rspec-rails
+  rswag
   rubocop (>= 1.0, < 2.0)
   selenium-webdriver
   sprockets-rails

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@
 
 ## 📖 About project - My Ruby on Rails Blog App <a name="about-project"></a>
 
-The My Ruby on Rails (RoR) Blog App is a complete Blog project including a PostgreSQL database connection, user authentication, CRUD operations, user validation, testing and API usage. Tenth part: Implementing authorization rule for deleting posts and comments, by using the CanCanCan gem.
+The My Ruby on Rails (RoR) Blog App is a complete Blog project including a PostgreSQL database connection, user authentication, CRUD operations, user validation, testing and API usage. This is the twelveth part: Documenting the API endpoints developed in the previous branch.
 
 ## 🛠 Built With <a name="built-with"></a>
 
@@ -56,6 +56,7 @@ The My Ruby on Rails (RoR) Blog App is a complete Blog project including a Postg
 - **Adding the Devise gem to our project for implementing user authentication.**
 - **Implementing authorization rules for deleting posts and comments, using the CanCanCan gem.**
 - **Adding endpoints: to list all posts of a user, to list all comments of a post, and to add a comment to a post.**
+- **API documentation.**
 
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
 
@@ -179,7 +180,7 @@ Not available at the moment.
 
 ## 🔭 Future Features <a name="future-features"></a>
 
-- **Add API documentation.**
+- **No future features.**
 
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
 

--- a/app/controllers/api/v1/posts_controller.rb
+++ b/app/controllers/api/v1/posts_controller.rb
@@ -5,6 +5,13 @@ module Api
       skip_before_action :authenticate_user!
 
       # Get api/v1/users/:user_id/posts
+      #
+      # @response_status 200
+      # @response_class Array<Post>
+      # @response_root posts
+      #
+      # @param user_id [integer] ID of the user whose posts are requested
+      #
       def index
         @user = User.find(params[:user_id])
         @posts = Post.where(author_id: params[:user_id])

--- a/config/initializers/rswag_api.rb
+++ b/config/initializers/rswag_api.rb
@@ -1,0 +1,14 @@
+Rswag::Api.configure do |c|
+
+  # Specify a root folder where Swagger JSON files are located
+  # This is used by the Swagger middleware to serve requests for API descriptions
+  # NOTE: If you're using rswag-specs to generate Swagger, you'll need to ensure
+  # that it's configured to generate files in the same folder
+  c.openapi_root = Rails.root.to_s + '/swagger'
+
+  # Inject a lambda function to alter the returned Swagger prior to serialization
+  # The function will have access to the rack env for the current request
+  # For example, you could leverage this to dynamically assign the "host" property
+  #
+  #c.swagger_filter = lambda { |swagger, env| swagger['host'] = env['HTTP_HOST'] }
+end

--- a/config/initializers/rswag_ui.rb
+++ b/config/initializers/rswag_ui.rb
@@ -1,0 +1,16 @@
+Rswag::Ui.configure do |c|
+
+  # List the Swagger endpoints that you want to be documented through the
+  # swagger-ui. The first parameter is the path (absolute or relative to the UI
+  # host) to the corresponding endpoint and the second is a title that will be
+  # displayed in the document selector.
+  # NOTE: If you're using rspec-api to expose Swagger files
+  # (under openapi_root) as JSON or YAML endpoints, then the list below should
+  # correspond to the relative paths for those endpoints.
+
+  c.swagger_endpoint '/api-docs/v1/swagger.yaml', 'API V1 Docs'
+
+  # Add Basic Auth in case your API is private
+  # c.basic_auth_enabled = true
+  # c.basic_auth_credentials 'username', 'password'
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,6 @@
 Rails.application.routes.draw do
+  mount Rswag::Ui::Engine => '/api-docs'
+  mount Rswag::Api::Engine => '/api-docs'
   devise_for :users #, path: 'devise'
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 

--- a/spec/requests/api/v1/posts_spec.rb
+++ b/spec/requests/api/v1/posts_spec.rb
@@ -1,0 +1,39 @@
+require 'swagger_helper'
+
+RSpec.describe 'api/v1/posts', type: :request do
+
+  path '/api/v1/users/{user_id}/posts' do
+    # You'll want to customize the parameter types...
+    parameter name: 'user_id', in: :path, type: :string, description: 'user_id'
+
+    get('list posts') do
+      response(200, 'successful') do
+        let(:user_id) { '123' }
+
+        after do |example|
+          example.metadata[:response][:content] = {
+            'application/json' => {
+              example: JSON.parse(response.body, symbolize_names: true)
+            }
+          }
+        end
+        run_test!
+      end
+    end
+
+    post('create post') do
+      response(200, 'successful') do
+        let(:user_id) { '123' }
+
+        after do |example|
+          example.metadata[:response][:content] = {
+            'application/json' => {
+              example: JSON.parse(response.body, symbolize_names: true)
+            }
+          }
+        end
+        run_test!
+      end
+    end
+  end
+end

--- a/spec/requests/api/v1/posts_spec.rb
+++ b/spec/requests/api/v1/posts_spec.rb
@@ -1,7 +1,6 @@
 require 'swagger_helper'
 
 RSpec.describe 'api/v1/posts', type: :request do
-
   consumes 'application/json'
   produces 'application/json'
   tags 'Posts'
@@ -10,7 +9,7 @@ RSpec.describe 'api/v1/posts', type: :request do
     # You'll want to customize the parameter types...
     parameter name: 'user_id', in: :path, type: :integer, description: 'user_id'
 
-    def set_response_example(example)
+    def response_example=(example)
       example.metadata[:response][:content] = {
         'application/json' => {
           example: JSON.parse(response.body, symbolize_names: true)

--- a/spec/requests/api/v1/posts_spec.rb
+++ b/spec/requests/api/v1/posts_spec.rb
@@ -2,36 +2,34 @@ require 'swagger_helper'
 
 RSpec.describe 'api/v1/posts', type: :request do
 
+  consumes 'application/json'
+  produces 'application/json'
+  tags 'Posts'
+
   path '/api/v1/users/{user_id}/posts' do
     # You'll want to customize the parameter types...
-    parameter name: 'user_id', in: :path, type: :string, description: 'user_id'
+    parameter name: 'user_id', in: :path, type: :integer, description: 'user_id'
+
+    def set_response_example(example)
+      example.metadata[:response][:content] = {
+        'application/json' => {
+          example: JSON.parse(response.body, symbolize_names: true)
+        }
+      }
+    end
 
     get('list posts') do
       response(200, 'successful') do
-        let(:user_id) { '123' }
-
-        after do |example|
-          example.metadata[:response][:content] = {
-            'application/json' => {
-              example: JSON.parse(response.body, symbolize_names: true)
-            }
-          }
-        end
+        let(:user_id) { 123 }
+        after { set_response_example(example) }
         run_test!
       end
     end
 
     post('create post') do
       response(200, 'successful') do
-        let(:user_id) { '123' }
-
-        after do |example|
-          example.metadata[:response][:content] = {
-            'application/json' => {
-              example: JSON.parse(response.body, symbolize_names: true)
-            }
-          }
-        end
+        let(:user_id) { 123 }
+        after { set_response_example(example) }
         run_test!
       end
     end

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.configure do |config|
+  # Specify a root folder where Swagger JSON files are generated
+  # NOTE: If you're using the rswag-api to serve API descriptions, you'll need
+  # to ensure that it's configured to serve Swagger from the same folder
+  config.openapi_root = Rails.root.join('swagger').to_s
+
+  # Define one or more Swagger documents and provide global metadata for each one
+  # When you run the 'rswag:specs:swaggerize' rake task, the complete Swagger will
+  # be generated at the provided relative path under openapi_root
+  # By default, the operations defined in spec files are added to the first
+  # document below. You can override this behavior by adding a openapi_spec tag to the
+  # the root example_group in your specs, e.g. describe '...', openapi_spec: 'v2/swagger.json'
+  config.openapi_specs = {
+    'v1/swagger.yaml' => {
+      openapi: '3.0.1',
+      info: {
+        title: 'API V1',
+        version: 'v1'
+      },
+      paths: {},
+      servers: [
+        {
+          url: 'https://{defaultHost}',
+          variables: {
+            defaultHost: {
+              default: 'www.example.com'
+            }
+          }
+        }
+      ]
+    }
+  }
+
+  # Specify the format of the output Swagger file when running 'rswag:specs:swaggerize'.
+  # The openapi_specs configuration option has the filename including format in
+  # the key, this may want to be changed to avoid putting yaml in json files.
+  # Defaults to json. Accepts ':json' and ':yaml'.
+  config.openapi_format = :yaml
+end

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -3,6 +3,8 @@
 require 'rails_helper'
 
 RSpec.configure do |config|
+  config.swagger_dry_run = false
+
   # Specify a root folder where Swagger JSON files are generated
   # NOTE: If you're using the rswag-api to serve API descriptions, you'll need
   # to ensure that it's configured to serve Swagger from the same folder
@@ -31,6 +33,20 @@ RSpec.configure do |config|
             }
           }
         }
+      ]
+    }
+  }
+
+  config.swagger_docs = {
+    'api/v1/swagger.json' => {
+      swagger: '2.0',
+      info: {
+        title: 'Your API Documentation',
+        version: 'v1'
+      },
+      tags: [
+        { name: 'swagger', description: 'Swagger API documentation tests' },
+        # ... other tags
       ]
     }
   }

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require 'rails_helper'
 
 RSpec.configure do |config|
@@ -45,7 +43,7 @@ RSpec.configure do |config|
         version: 'v1'
       },
       tags: [
-        { name: 'swagger', description: 'Swagger API documentation tests' },
+        { name: 'swagger', description: 'Swagger API documentation tests' }
         # ... other tags
       ]
     }

--- a/swagger/api/v1/swagger.json
+++ b/swagger/api/v1/swagger.json
@@ -1,0 +1,8 @@
+---
+swagger: '2.0'
+info:
+  title: Your API Documentation
+  version: v1
+tags:
+- name: swagger
+  description: Swagger API documentation tests


### PR DESCRIPTION
### Exercise
In this exercise, you will add documentation for your API endpoints using [rswag](https://github.com/rswag/rswag). Remember that this involves writing the specs that will then be turned into actual documentation and accessible in [swagger-ui](https://github.com/swagger-api/swagger-ui) at /api-docs

### Instructions
- Write the API integration specs using [rswag](https://github.com/rswag/rswag#getting-started) for your existing endpoints.
- Generate the documentation.